### PR TITLE
Added useWebGL

### DIFF
--- a/src/components/Content/PlotWidget/PlotSettingsPopup/PlotSettingsPopup.tsx
+++ b/src/components/Content/PlotWidget/PlotSettingsPopup/PlotSettingsPopup.tsx
@@ -250,15 +250,15 @@ const PlotSettingsPopup: React.FC<PlotSettingsPopupProps> = ({
                                                             }
                                                         >
                                                             <MenuItem value="lines+markers">
-                                                                lines and
-                                                                markers
+                                                                Lines and
+                                                                Markers
                                                             </MenuItem>
                                                             <MenuItem value="markers">
-                                                                only markers
+                                                                Only Markers
                                                                 (points)
                                                             </MenuItem>
                                                             <MenuItem value="lines">
-                                                                only lines
+                                                                Only Lines
                                                             </MenuItem>
                                                         </Select>
                                                     </Tooltip>

--- a/src/components/Content/PlotWidget/PlotWidget.tsx
+++ b/src/components/Content/PlotWidget/PlotWidget.tsx
@@ -104,17 +104,20 @@ const PlotWidget: React.FC<PlotWidgetProps> = React.memo(
 
         const [plotBackgroundColor] = useLocalStorage(
             "plotBackgroundColor",
-            defaultPlotBackgroundColor
+            defaultPlotBackgroundColor,
+            true
         );
         const [xAxisGridColor] = useLocalStorage(
             "xAxisGridColor",
-            defaultXAxisGridColor
+            defaultXAxisGridColor,
+            true
         );
         const [yAxisGridColor] = useLocalStorage(
             "yAxisGridColor",
-            defaultYAxisGridColor
+            defaultYAxisGridColor,
+            true
         );
-        const [useWebGL] = useLocalStorage("useWebGL", defaultUseWebGL);
+        const [useWebGL] = useLocalStorage("useWebGL", defaultUseWebGL, true);
 
         const isCtrlPressed = useRef(false);
         const containerRef = useRef<HTMLDivElement | null>(null);

--- a/src/components/Content/PlotWidget/PlotWidget.tsx
+++ b/src/components/Content/PlotWidget/PlotWidget.tsx
@@ -29,6 +29,7 @@ import {
     defaultCurveMode,
     defaultCurveShape,
     defaultPlotBackgroundColor,
+    defaultUseWebGL,
     defaultXAxisGridColor,
     defaultYAxisGridColor,
     defaultYAxisScaling,
@@ -113,6 +114,7 @@ const PlotWidget: React.FC<PlotWidgetProps> = React.memo(
             "yAxisGridColor",
             defaultYAxisGridColor
         );
+        const [useWebGL] = useLocalStorage("useWebGL", defaultUseWebGL);
 
         const isCtrlPressed = useRef(false);
         const containerRef = useRef<HTMLDivElement | null>(null);
@@ -885,7 +887,7 @@ const PlotWidget: React.FC<PlotWidgetProps> = React.memo(
                     name: displayLabel,
                     x: xValues,
                     y: yBase,
-                    type: "scattergl",
+                    type: useWebGL ? "scattergl" : "scatter",
                     mode: mode,
                     yaxis: yAxis === "y1" ? "y" : yAxis,
                     line: { color: color, shape: shape },
@@ -893,7 +895,7 @@ const PlotWidget: React.FC<PlotWidgetProps> = React.memo(
                 result.push({
                     x: xPolygon,
                     y: yPolygon,
-                    type: "scattergl",
+                    type: useWebGL ? "scattergl" : "scatter",
                     mode: "lines",
                     fill: "toself",
                     fillcolor: hexToRgba(color, 0.3),
@@ -907,7 +909,7 @@ const PlotWidget: React.FC<PlotWidgetProps> = React.memo(
 
             result.push(...values);
             return result;
-        }, [curves, curveAttributes, getLabelForCurve]);
+        }, [curves, curveAttributes, useWebGL, getLabelForCurve]);
 
         const layout = useMemo(() => {
             const yAxes: { [key: string]: Partial<Plotly.LayoutAxis> }[] = [];

--- a/src/components/GeneralSettingsPopup/GeneralSettingsPopup.styles.ts
+++ b/src/components/GeneralSettingsPopup/GeneralSettingsPopup.styles.ts
@@ -38,3 +38,15 @@ export const resetButtonStyle: SxProps<Theme> = {
     justifyContent: "center",
     marginTop: "15px",
 };
+
+export const warningStyle: SxProps<Theme> = {
+    color: "orange",
+    marginTop: "8px",
+    fontWeight: "bold",
+};
+
+export const errorStyle: SxProps<Theme> = {
+    color: "red",
+    marginTop: "8px",
+    fontWeight: "bold",
+};

--- a/src/helpers/defaults.ts
+++ b/src/helpers/defaults.ts
@@ -1,6 +1,8 @@
 export const defaultPlotBackgroundColor = "#fcfcfc";
 export const defaultXAxisGridColor = "#ebebeb";
 export const defaultYAxisGridColor = "#ebebeb";
+export const defaultUseWebGL = true;
+
 export const defaultCurveColors = [
     "#1f77b4",
     "#ff7f0e",

--- a/src/helpers/useLocalStorage.ts
+++ b/src/helpers/useLocalStorage.ts
@@ -25,8 +25,11 @@ export const useLocalStorage = <T>(
         parsedValue = JSON.parse(storedValue);
     } else {
         parsedValue = initialValue as T;
-        // Store the initialValue in localStorage if it doesn't exist
-        localStorage.setItem(key, JSON.stringify(initialValue));
+
+        if (initialValue !== null) {
+            // Store the initialValue in localStorage if it doesn't exist
+            localStorage.setItem(key, JSON.stringify(initialValue));
+        }
     }
 
     const [value, setValue] = useState<T>(parsedValue);

--- a/src/helpers/useLocalStorage.ts
+++ b/src/helpers/useLocalStorage.ts
@@ -20,7 +20,14 @@ export const useLocalStorage = <T>(
 ): [T, React.Dispatch<React.SetStateAction<T>>] => {
     // Retrieve and parse the stored value, or use the initial value if not present.
     const storedValue = localStorage.getItem(key);
-    const parsedValue = storedValue ? JSON.parse(storedValue) : initialValue;
+    let parsedValue: T;
+    if (storedValue !== null) {
+        parsedValue = JSON.parse(storedValue);
+    } else {
+        parsedValue = initialValue as T;
+        // Store the initialValue in localStorage if it doesn't exist
+        localStorage.setItem(key, JSON.stringify(initialValue));
+    }
 
     const [value, setValue] = useState<T>(parsedValue);
 

--- a/src/helpers/useLocalStorage.ts
+++ b/src/helpers/useLocalStorage.ts
@@ -12,11 +12,15 @@ import { useState, useEffect } from "react";
  * @template T - The type of the value being stored (e.g., string, number).
  * @param key - The localStorage key.
  * @param initialValue - The initial value to use if the key is not found in localStorage.
+ * @param readOnly - If true, the value is only read from localStorage and updates
+ *                   will only apply to the local state. However, any changes made
+ *                   externally in localStorage will overwrite the local state.
  * @returns A stateful value and a setter function that updates both state and localStorage.
  */
 export const useLocalStorage = <T>(
     key: string,
-    initialValue?: T
+    initialValue?: T,
+    readOnly: boolean = false
 ): [T, React.Dispatch<React.SetStateAction<T>>] => {
     // Retrieve and parse the stored value, or use the initial value if not present.
     const storedValue = localStorage.getItem(key);
@@ -26,7 +30,7 @@ export const useLocalStorage = <T>(
     } else {
         parsedValue = initialValue as T;
 
-        if (initialValue !== null) {
+        if (initialValue !== undefined && !readOnly) {
             // Store the initialValue in localStorage if it doesn't exist
             localStorage.setItem(key, JSON.stringify(initialValue));
         }
@@ -39,13 +43,15 @@ export const useLocalStorage = <T>(
         newValue
     ) => {
         setValue(newValue);
-        localStorage.setItem(key, JSON.stringify(newValue));
-        // Dispatch a custom event so other hook instances in the same tab update.
-        window.dispatchEvent(
-            new CustomEvent("localStorageUpdate", {
-                detail: { key, newValue },
-            })
-        );
+        if (!readOnly) {
+            localStorage.setItem(key, JSON.stringify(newValue));
+            // Dispatch a custom event so other hook instances in the same tab update.
+            window.dispatchEvent(
+                new CustomEvent("localStorageUpdate", {
+                    detail: { key, newValue },
+                })
+            );
+        }
     };
 
     useEffect(() => {


### PR DESCRIPTION
Closes #30 

This adds the option to disable the use of WebGL, which will make lines rendered using scattergl instead of scatter.  It also displays a warning if scattegl is disabled, even though the browser is capable of it, and an error if it's enabled, but the browser doesnt support it. Additionally, the default is initialized based on measured webgl support.

There is also a change to useLocalStorage, to now store the initial value immediately, before it only stored it once it was explicitly set. Also, there is now a readonly mode, that prevents race conditions when plotwidget and generalsettings both provide a default value