### PR TITLE
Implemented dynamic default sidebar state

### DIFF
--- a/src/components/GeneralSettingsPopup/GeneralSettingsPopup.tsx
+++ b/src/components/GeneralSettingsPopup/GeneralSettingsPopup.tsx
@@ -23,6 +23,7 @@ import {
     defaultCurveColors,
     defaultCurveMode,
     defaultCurveShape,
+    defaultInitialSidebarState,
     defaultPlotBackgroundColor,
     defaultUseWebGL,
     defaultWidgetHeight,
@@ -32,11 +33,16 @@ import {
     defaultYAxisScaling,
 } from "../../helpers/defaults";
 import Plot from "react-plotly.js";
+import { InitialSidebarState } from "../Sidebar/Sidebar.types";
 
 const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
     open,
     onClose,
 }) => {
+    const [initialSidebarState, setInitialSidebarState] = useLocalStorage(
+        "initialSidebarState",
+        defaultInitialSidebarState
+    );
     const [plotBackgroundColor, setPlotBackgroundColor] = useLocalStorage(
         "plotBackgroundColor",
         defaultPlotBackgroundColor
@@ -79,6 +85,7 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
     );
 
     const resetToDefaults = () => {
+        setInitialSidebarState(defaultInitialSidebarState);
         setPlotBackgroundColor(defaultPlotBackgroundColor);
         setXAxisGridColor(defaultXAxisGridColor);
         setYAxisGridColor(defaultYAxisGridColor);
@@ -135,6 +142,29 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
                 <Typography variant="h4" sx={{ marginBottom: "8px" }}>
                     General
                 </Typography>
+
+                <Box sx={styles.settingBoxStyle}>
+                    <FormControl fullWidth>
+                        <InputLabel>Initial Sidebar State</InputLabel>
+                        <Select
+                            value={initialSidebarState}
+                            onChange={(e) =>
+                                setInitialSidebarState(
+                                    e.target.value as InitialSidebarState
+                                )
+                            }
+                            label="Initial Sidebar State"
+                        >
+                            <MenuItem value="closedIfDashboard">
+                                Closed if Dashboard is Provided
+                            </MenuItem>
+                            <MenuItem value="alwaysOpen">Always Open</MenuItem>
+                            <MenuItem value="alwaysClosed">
+                                Always Closed
+                            </MenuItem>
+                        </Select>
+                    </FormControl>
+                </Box>
 
                 <Box sx={styles.settingBoxStyle}>
                     <Typography variant="h6">Plot Background Color</Typography>

--- a/src/components/GeneralSettingsPopup/GeneralSettingsPopup.tsx
+++ b/src/components/GeneralSettingsPopup/GeneralSettingsPopup.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
     Dialog,
     DialogTitle,
@@ -39,6 +39,22 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
     open,
     onClose,
 }) => {
+    const isWebGLSupported = useMemo(() => {
+        try {
+            const canvas = document.createElement("canvas");
+            if (
+                !window.WebGLRenderingContext ||
+                (!canvas.getContext("webgl") &&
+                    !canvas.getContext("experimental-webgl"))
+            ) {
+                return false;
+            }
+            return true;
+        } catch {
+            return false;
+        }
+    }, []);
+
     const [initialSidebarState, setInitialSidebarState] = useLocalStorage(
         "initialSidebarState",
         defaultInitialSidebarState
@@ -57,7 +73,7 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
     );
     const [useWebGL, setUseWebGL] = useLocalStorage(
         "useWebGL",
-        isWebGLSupported() ? defaultUseWebGL : false
+        isWebGLSupported ? defaultUseWebGL : false
     );
     const [initialWidgetHeight, setInitialWidgetHeight] = useLocalStorage(
         "initialWidgetHeight",
@@ -89,7 +105,7 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
         setPlotBackgroundColor(defaultPlotBackgroundColor);
         setXAxisGridColor(defaultXAxisGridColor);
         setYAxisGridColor(defaultYAxisGridColor);
-        setUseWebGL(isWebGLSupported() ? defaultUseWebGL : false);
+        setUseWebGL(isWebGLSupported ? defaultUseWebGL : false);
         setInitialWidgetHeight(defaultWidgetHeight);
         setInitialWidgetWidth(defaultWidgetWidth);
         setCurveColors(defaultCurveColors);
@@ -97,20 +113,6 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
         setCurveShape(defaultCurveShape);
         setCurveMode(defaultCurveMode);
     };
-
-    // from https://stackoverflow.com/a/22953053/21240915
-    function isWebGLSupported() {
-        try {
-            const canvas = document.createElement("canvas");
-            return (
-                !!window.WebGLRenderingContext &&
-                (canvas.getContext("webgl") ||
-                    canvas.getContext("experimental-webgl"))
-            );
-        } catch {
-            return false;
-        }
-    }
 
     return (
         <Dialog
@@ -216,14 +218,14 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
                             </Select>
                         </Tooltip>
                     </FormControl>
-                    {!isWebGLSupported() && useWebGL && (
+                    {!isWebGLSupported && useWebGL && (
                         <Typography variant="body2" sx={styles.errorStyle}>
                             ⚠ Your browser does not meet WebGL requirements.
                             The plots will probably break.
                         </Typography>
                     )}
 
-                    {isWebGLSupported() && !useWebGL && (
+                    {isWebGLSupported && !useWebGL && (
                         <Typography variant="body2" sx={styles.warningStyle}>
                             ⚠ WebGL is disabled. Enabling it can drastically
                             improve performance.

--- a/src/components/Sidebar/Sidebar.types.ts
+++ b/src/components/Sidebar/Sidebar.types.ts
@@ -2,3 +2,8 @@ export interface SidebarProps {
     initialWidthPercent?: number;
     maxWidthPercent?: number;
 }
+
+export type InitialSidebarState =
+    | "alwaysOpen"
+    | "alwaysClosed"
+    | "closedIfDashboard";

--- a/src/helpers/defaults.ts
+++ b/src/helpers/defaults.ts
@@ -1,3 +1,5 @@
+import { InitialSidebarState } from "../components/Sidebar/Sidebar.types";
+
 export const defaultPlotBackgroundColor = "#fcfcfc";
 export const defaultXAxisGridColor = "#ebebeb";
 export const defaultYAxisGridColor = "#ebebeb";
@@ -21,3 +23,6 @@ export const defaultCurveMode = "lines+markers";
 
 export const defaultWidgetWidth = 6;
 export const defaultWidgetHeight = 12;
+
+export const defaultInitialSidebarState: InitialSidebarState =
+    "closedIfDashboard";

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -2,8 +2,20 @@ import React from "react";
 import { Box } from "@mui/material";
 import Sidebar from "../components/Sidebar/Sidebar";
 import Content from "../components/Content/Content";
+import { defaultInitialSidebarState } from "../helpers/defaults";
+import { InitialSidebarState } from "../components/Sidebar/Sidebar.types";
 
 const DashboardLayout: React.FC = () => {
+    const initialSidebarState = JSON.parse(
+        localStorage.getItem("initialSidebarState") ||
+            JSON.stringify(defaultInitialSidebarState)
+    ) as InitialSidebarState;
+
+    const isSidebarOpen =
+        initialSidebarState === "alwaysOpen" ||
+        (initialSidebarState !== "alwaysClosed" &&
+            !new URLSearchParams(window.location.search).get("dashboardId"));
+
     return (
         <Box
             sx={{
@@ -14,10 +26,11 @@ const DashboardLayout: React.FC = () => {
             }}
         >
             <Sidebar
-                initialWidthPercent={Math.min(
-                    30,
-                    (100 * 800) / window.innerWidth
-                )}
+                initialWidthPercent={
+                    isSidebarOpen
+                        ? Math.min(30, (100 * 800) / window.innerWidth)
+                        : 0
+                }
                 maxWidthPercent={Math.min(80, (100 * 800) / window.innerWidth)}
             />
             <Content />


### PR DESCRIPTION
Closes #39 

Now, a setting controls, whether or not the sidebar is open upon page load, or not.

I also memoized the webgl context-checking function, to avoid it from rechecking all the time, and therefore creating unnecessary webgl contexts, which creates errors.