### PR TITLE
Optimized color pickers

### DIFF
--- a/src/components/Content/PlotWidget/PlotSettingsPopup/PlotSettingsPopup.tsx
+++ b/src/components/Content/PlotWidget/PlotSettingsPopup/PlotSettingsPopup.tsx
@@ -179,11 +179,13 @@ const PlotSettingsPopup: React.FC<PlotSettingsPopupProps> = ({
                                                 <TableCell>
                                                     <Input
                                                         type="color"
-                                                        value={attr.color}
+                                                        defaultValue={
+                                                            attr.color
+                                                        }
                                                         sx={
                                                             styles.colorPickerStyle
                                                         }
-                                                        onChange={(e) =>
+                                                        onBlur={(e) =>
                                                             handleCurveAttributesChanged(
                                                                 key,
                                                                 "color",

--- a/src/components/GeneralSettingsPopup/GeneralSettingsPopup.tsx
+++ b/src/components/GeneralSettingsPopup/GeneralSettingsPopup.tsx
@@ -241,18 +241,20 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
                     <Typography variant="h6">Plot Background Color</Typography>
                     <Input
                         type="color"
-                        value={plotBackgroundColor}
-                        onChange={(e) => setPlotBackgroundColor(e.target.value)}
+                        key={plotBackgroundColor}
+                        defaultValue={plotBackgroundColor} // Bind the value directly to the state
+                        onBlur={(e) => setPlotBackgroundColor(e.target.value)}
                         sx={styles.colorPickerStyle}
-                    ></Input>
+                    />
                 </Box>
 
                 <Box sx={styles.settingBoxStyle}>
                     <Typography variant="h6">X-Axis Grid Color</Typography>
                     <Input
                         type="color"
-                        value={xAxisGridColor}
-                        onChange={(e) => setXAxisGridColor(e.target.value)}
+                        key={xAxisGridColor}
+                        defaultValue={xAxisGridColor}
+                        onBlur={(e) => setXAxisGridColor(e.target.value)}
                         sx={styles.colorPickerStyle}
                     ></Input>
                 </Box>
@@ -261,8 +263,9 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
                     <Typography variant="h6">Y-Axis Grid Color</Typography>
                     <Input
                         type="color"
-                        value={yAxisGridColor}
-                        onChange={(e) => setYAxisGridColor(e.target.value)}
+                        key={yAxisGridColor}
+                        defaultValue={yAxisGridColor}
+                        onBlur={(e) => setYAxisGridColor(e.target.value)}
                         sx={styles.colorPickerStyle}
                     ></Input>
                 </Box>
@@ -373,8 +376,9 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
                             <Box key={index} sx={{ marginBottom: "8px" }}>
                                 <Input
                                     type="color"
-                                    value={color}
-                                    onChange={(e) => {
+                                    key={curveColors[index]}
+                                    defaultValue={color}
+                                    onBlur={(e) => {
                                         const updatedColors = [...curveColors];
                                         updatedColors[index] = e.target.value;
                                         setCurveColors(updatedColors);

--- a/src/components/GeneralSettingsPopup/GeneralSettingsPopup.tsx
+++ b/src/components/GeneralSettingsPopup/GeneralSettingsPopup.tsx
@@ -34,6 +34,7 @@ import {
 } from "../../helpers/defaults";
 import Plot from "react-plotly.js";
 import { InitialSidebarState } from "../Sidebar/Sidebar.types";
+import { debounce } from "lodash";
 
 const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
     open,
@@ -63,13 +64,25 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
         "plotBackgroundColor",
         defaultPlotBackgroundColor
     );
+    const debouncedSetPlotBackgroundColor = useMemo(
+        () => debounce((color: string) => setPlotBackgroundColor(color), 100),
+        [setPlotBackgroundColor]
+    );
     const [xAxisGridColor, setXAxisGridColor] = useLocalStorage(
         "xAxisGridColor",
         defaultXAxisGridColor
     );
+    const debouncedSetXAxisGridColor = useMemo(
+        () => debounce((color: string) => setXAxisGridColor(color), 100),
+        [setXAxisGridColor]
+    );
     const [yAxisGridColor, setYAxisGridColor] = useLocalStorage(
         "yAxisGridColor",
         defaultYAxisGridColor
+    );
+    const debouncedSetYAxisGridColor = useMemo(
+        () => debounce((color: string) => setYAxisGridColor(color), 100),
+        [setYAxisGridColor]
     );
     const [useWebGL, setUseWebGL] = useLocalStorage(
         "useWebGL",
@@ -86,6 +99,10 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
     const [curveColors, setCurveColors] = useLocalStorage(
         "curveColors",
         defaultCurveColors
+    );
+    const debouncedSetCurveColors = useMemo(
+        () => debounce((colors: string[]) => setCurveColors(colors), 100),
+        [setCurveColors]
     );
     const [yAxisScaling, setYAxisScaling] = useLocalStorage(
         "yAxisScaling",
@@ -241,9 +258,10 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
                     <Typography variant="h6">Plot Background Color</Typography>
                     <Input
                         type="color"
-                        key={plotBackgroundColor}
-                        defaultValue={plotBackgroundColor} // Bind the value directly to the state
-                        onBlur={(e) => setPlotBackgroundColor(e.target.value)}
+                        value={plotBackgroundColor}
+                        onChange={(e) =>
+                            debouncedSetPlotBackgroundColor(e.target.value)
+                        }
                         sx={styles.colorPickerStyle}
                     />
                 </Box>
@@ -252,9 +270,10 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
                     <Typography variant="h6">X-Axis Grid Color</Typography>
                     <Input
                         type="color"
-                        key={xAxisGridColor}
-                        defaultValue={xAxisGridColor}
-                        onBlur={(e) => setXAxisGridColor(e.target.value)}
+                        value={xAxisGridColor}
+                        onChange={(e) =>
+                            debouncedSetXAxisGridColor(e.target.value)
+                        }
                         sx={styles.colorPickerStyle}
                     ></Input>
                 </Box>
@@ -263,9 +282,10 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
                     <Typography variant="h6">Y-Axis Grid Color</Typography>
                     <Input
                         type="color"
-                        key={yAxisGridColor}
-                        defaultValue={yAxisGridColor}
-                        onBlur={(e) => setYAxisGridColor(e.target.value)}
+                        value={yAxisGridColor}
+                        onChange={(e) =>
+                            debouncedSetYAxisGridColor(e.target.value)
+                        }
                         sx={styles.colorPickerStyle}
                     ></Input>
                 </Box>
@@ -376,12 +396,11 @@ const GeneralSettingsPopup: React.FC<GeneralSettingsPopupProps> = ({
                             <Box key={index} sx={{ marginBottom: "8px" }}>
                                 <Input
                                     type="color"
-                                    key={curveColors[index]}
-                                    defaultValue={color}
-                                    onBlur={(e) => {
+                                    value={color}
+                                    onChange={(e) => {
                                         const updatedColors = [...curveColors];
                                         updatedColors[index] = e.target.value;
-                                        setCurveColors(updatedColors);
+                                        debouncedSetCurveColors(updatedColors);
                                     }}
                                     sx={styles.colorPickerStyle}
                                 />


### PR DESCRIPTION
Optimized color pickers to reduce lag and enable smooth pointer dragging across color palette. This was done in two separate ways:

Plot Specific Settings:
Using onBlur and DefaultValue, the input is decoupled from the stored value, and only saved once something else is focused (neccessary to close the settings popup)

General Settings:
Since here, the value might change from outside, the input cannot be decoupled, and defaultvalue doesn't work. Here the compromise is to use debounce to wait until the user doesnt change anything for 100ms to apply it. This has the nice effect that dragging along the picker canvas does not cause a bazillion renders. (Yes, I tried throttle too, that's not suitable here though, since firing all 100ms while dragging along the picker canvas also produces lag)
So after all it's not as nice as in the plot specific settings, since you do notice the debounce working (as intended), however this shouldn't be too much of an issue.