### PR TITLE
Fix/make to image include legend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "@types/lodash": "^4.17.16",
                 "@types/node": "^22.14.0",
                 "@types/plotly.js": "^2.35.5",
-                "@types/react": "^19.1.0",
+                "@types/react": "^19.1.1",
                 "@types/react-dom": "^19.1.2",
                 "@types/react-grid-layout": "^1.3.5",
                 "@types/react-window": "^1.8.8",
@@ -2766,9 +2766,9 @@
             "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
         },
         "node_modules/@types/react": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
-            "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
+            "version": "19.1.1",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.1.tgz",
+            "integrity": "sha512-ePapxDL7qrgqSF67s0h9m412d9DbXyC1n59O2st+9rjuuamWsZuD2w55rqY12CbzsZ7uVXb5Nw0gEp9Z8MMutQ==",
             "dependencies": {
                 "csstype": "^3.0.2"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "@mui/x-date-pickers": "^7.28.3",
                 "axios": "^1.8.4",
                 "dayjs": "^1.11.13",
+                "html2canvas": "^1.4.1",
                 "lodash": "^4.17.21",
                 "plotly.js": "^3.0.1",
                 "re-resizable": "^6.11.2",
@@ -30,6 +31,7 @@
             "devDependencies": {
                 "@eslint/js": "^9.22.0",
                 "@testing-library/jest-dom": "^6.6.3",
+                "@types/html2canvas": "^1.0.0",
                 "@types/jest": "^29.5.14",
                 "@types/lodash": "^4.17.16",
                 "@types/node": "^22.14.0",
@@ -2658,6 +2660,16 @@
                 "@types/geojson": "*"
             }
         },
+        "node_modules/@types/html2canvas": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/html2canvas/-/html2canvas-1.0.0.tgz",
+            "integrity": "sha512-BJpVf+FIN9UERmzhbtUgpXj6XBZpG67FMgBLLoj9HZKd9XifcCpSV+UnFcwTZfEyun4U/KmCrrVOG7829L589w==",
+            "deprecated": "This is a stub types definition. html2canvas provides its own type definitions, so you do not need this installed.",
+            "dev": true,
+            "dependencies": {
+                "html2canvas": "*"
+            }
+        },
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -4341,6 +4353,14 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
             "integrity": "sha512-X1xgQhkZ9n94WDwntqst5D/FKkmiU0GlJSFZSV3kLvyJ1WC5VeyoXDOuleUD+SIuH9C7W05is++0Woh0CGfKjQ=="
+        },
+        "node_modules/css-line-break": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+            "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+            "dependencies": {
+                "utrie": "^1.0.2"
+            }
         },
         "node_modules/css-loader": {
             "version": "7.1.2",
@@ -6221,6 +6241,18 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/html2canvas": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+            "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+            "dependencies": {
+                "css-line-break": "^2.1.0",
+                "text-segmentation": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "node_modules/http-proxy-agent": {
@@ -9502,6 +9534,14 @@
                 }
             }
         },
+        "node_modules/text-segmentation": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+            "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+            "dependencies": {
+                "utrie": "^1.0.2"
+            }
+        },
         "node_modules/through2": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -9844,6 +9884,14 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+        },
+        "node_modules/utrie": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+            "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+            "dependencies": {
+                "base64-arraybuffer": "^1.0.2"
+            }
         },
         "node_modules/uuid": {
             "version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "@mui/x-date-pickers": "^7.28.3",
         "axios": "^1.8.4",
         "dayjs": "^1.11.13",
+        "html2canvas": "^1.4.1",
         "lodash": "^4.17.21",
         "plotly.js": "^3.0.1",
         "re-resizable": "^6.11.2",
@@ -35,6 +36,7 @@
     "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@testing-library/jest-dom": "^6.6.3",
+        "@types/html2canvas": "^1.0.0",
         "@types/jest": "^29.5.14",
         "@types/lodash": "^4.17.16",
         "@types/node": "^22.14.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "@types/lodash": "^4.17.16",
         "@types/node": "^22.14.0",
         "@types/plotly.js": "^2.35.5",
-        "@types/react": "^19.1.0",
+        "@types/react": "^19.1.1",
         "@types/react-dom": "^19.1.2",
         "@types/react-grid-layout": "^1.3.5",
         "@types/react-window": "^1.8.8",


### PR DESCRIPTION
Since Plotly's ToImage cannot capture our custom legend, and html2canvas didn't capture the watermark (Plotly appends it to teh DOM in a very weird way, probably with absolute pixel values, or something else that makes it invisble to html2canvas...), I created a custom toImage Button that when clicked combines the ouptu from Plotly for the plot and from html2canvas for the legend to download an actual image of the plot including image and watermark (if displayed). If the legend overflows, this won't capture all legend entries, but that's how the plot is shown to the user, so that's how we'll download it, for now. It's pretty much a tool that helps screenshot the correct space, but also makes sure the screenshot has decent quality (4x Scale).

Closes #114 